### PR TITLE
Move fns related to reviewMetadata API to utilityFns for shared use

### DIFF
--- a/client/src/components/Reviews/ReviewSummary/index.jsx
+++ b/client/src/components/Reviews/ReviewSummary/index.jsx
@@ -3,13 +3,15 @@ import PropTypes from 'prop-types';
 import AverageRating from './AverageRating.jsx';
 import RatingBreakdown from './RatingBreakdown.jsx';
 import ProductBreakdown from './ProductBreakdown.jsx';
-import sharedFns from '../../SharedComponents/sharedFns.js';
+import utilityFns from '../../../utilityFns.js';
 
 // TODO: add tests for AverageRating,
 // RatingBreakdown, and ProductBreakdown components
 
 const ReviewSummary = ({ reviewsMetadata, updateFilters }) => {
-  let { totalRatings, percentageRecommended, averageRating } = sharedFns.calculateAverageRating(reviewsMetadata);
+  let { totalRatings,
+    percentageRecommended,
+    averageRating } = utilityFns.processReviewMetadata(reviewsMetadata);
   return (
     <div style={{width: '5 em'}}>
       <AverageRating

--- a/client/src/components/Reviews/ReviewSummary/index.jsx
+++ b/client/src/components/Reviews/ReviewSummary/index.jsx
@@ -3,22 +3,13 @@ import PropTypes from 'prop-types';
 import AverageRating from './AverageRating.jsx';
 import RatingBreakdown from './RatingBreakdown.jsx';
 import ProductBreakdown from './ProductBreakdown.jsx';
+import sharedFns from '../../SharedComponents/sharedFns.js';
 
 // TODO: add tests for AverageRating,
 // RatingBreakdown, and ProductBreakdown components
 
 const ReviewSummary = ({ reviewsMetadata, updateFilters }) => {
-  const ratings = reviewsMetadata.ratings || {};
-  const totalRatings = Object.values(ratings)
-    .reduce((prev, curr) => { return prev + Number(curr); }, 0);
-  const averageRating = totalRatings === 0 ? 0 : (Object.keys(ratings)
-    .reduce((prev, key) => {
-      let rating = Number(key);
-      let ratingCount = Number(ratings[key]);
-      return rating * ratingCount + prev;
-    }, 0) / totalRatings);
-  const recommendedCount = reviewsMetadata.recommended.true || 0;
-  const percentageRecommended = Math.floor(recommendedCount / totalRatings * 100);
+  let { totalRatings, percentageRecommended, averageRating } = sharedFns.calculateAverageRating(reviewsMetadata);
   return (
     <div style={{width: '5 em'}}>
       <AverageRating

--- a/client/src/components/SharedComponents/sharedFns.js
+++ b/client/src/components/SharedComponents/sharedFns.js
@@ -1,0 +1,18 @@
+const sharedFns = {
+  calculateAverageRating: (reviewsMetadata) => {
+    const ratings = reviewsMetadata.ratings || {};
+    const totalRatings = Object.values(ratings)
+      .reduce((prev, curr) => { return prev + Number(curr); }, 0);
+    const averageRating = totalRatings === 0 ? 0 : (Object.keys(ratings)
+      .reduce((prev, key) => {
+        let rating = Number(key);
+        let ratingCount = Number(ratings[key]);
+        return rating * ratingCount + prev;
+      }, 0) / totalRatings);
+    const recommendedCount = reviewsMetadata.recommended.true || 0;
+    const percentageRecommended = Math.floor(recommendedCount / totalRatings * 100);
+    return { totalRatings, averageRating, recommendedCount, percentageRecommended };
+  },
+};
+
+export default sharedFns;

--- a/client/src/utilityFns.js
+++ b/client/src/utilityFns.js
@@ -1,4 +1,4 @@
-const sharedFns = {
+const utilityFns = {
   processReviewMetadata: (reviewsMetadata) => {
     const ratings = reviewsMetadata.ratings || {};
     const totalRatings = Object.values(ratings)
@@ -15,4 +15,4 @@ const sharedFns = {
   },
 };
 
-export default sharedFns;
+export default utilityFns;

--- a/client/src/utilityFns.js
+++ b/client/src/utilityFns.js
@@ -1,5 +1,5 @@
 const sharedFns = {
-  calculateAverageRating: (reviewsMetadata) => {
+  processReviewMetadata: (reviewsMetadata) => {
     const ratings = reviewsMetadata.ratings || {};
     const totalRatings = Object.values(ratings)
       .reduce((prev, curr) => { return prev + Number(curr); }, 0);


### PR DESCRIPTION
## Description:
Moved functions related to reviewMetadata API into a utilityFns.processReviewMetadata method.

## Context:
This shared function takes the data (an object) returned from the  GET /reviews/meta endpoint as input and returns: totalRatings, averageRating, recommendedCount, percentageRecommended (integers) as output. 

## Checklist:
[x] Moved processReviewMetadata data processing into a separate directory
[x] updated ReviewSummary.index.js to make use of the processReviewMetadata function

## Notes:
sample usage:
```
import utilityFns from '../RELATIVE/PATH/utilityFns.js';
//... some code...///
let { totalRatings, percentageRecommended, averageRating } = utilityFns.processReviewMetadata(reviewsMetadata);
```
### Screenshots (if any):
n/a

## Link to story (if available):
n/a