### PR TITLE
Webpack dev config

### DIFF
--- a/client/dist/template.html
+++ b/client/dist/template.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
+      integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://unpkg.com/flickity@2/dist/flickity.min.css">
+
+    <title>Front End Capstone</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/flickity@2/dist/flickity.pkgd.min.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "react-dev": "webpack --watch",
+    "start": "webpack-dev-server --config webpack.dev.js --open",
+    "build": "webpack --config webpack.prod.js",
     "start-server": "npx nodemon server/index.js"
   },
   "repository": {
@@ -36,10 +37,14 @@
     "eslint": "^8.5.0",
     "eslint-plugin-react": "^7.28.0",
     "file-loader": "^6.2.0",
+    "html-loader": "^3.0.1",
+    "html-webpack-plugin": "^5.5.0",
     "jest": "^27.4.5",
     "nodemon": "^2.0.15",
     "style-loader": "^3.3.1",
     "webpack": "^5.65.0",
-    "webpack-cli": "^4.9.1"
+    "webpack-cli": "^4.9.1",
+    "webpack-dev-server": "^4.7.2",
+    "webpack-merge": "^5.8.0"
   }
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,10 +1,25 @@
 
+const path = require('path');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+
 module.exports = {
-  entry: __dirname + '/client/src/index.jsx',
-  devtool: 'source-map',
-  mode: 'production',
+  entry: path.resolve(__dirname + '/client/src/index.jsx'),
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: 'client/dist/template.html',
+      inject: 'body'
+    })
+  ],
   module: {
     rules: [
+      {
+        test: /\.html$/,
+        use: [
+          {
+            loader: 'html-loader',
+          }
+        ]
+      },
       {
         test: [/\.jsx$/],
         exclude: /node_modules/,
@@ -17,7 +32,7 @@ module.exports = {
       },
       {
         test: /\.css$/i,
-        use: ["style-loader", "css-loader"],
+        use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.(png|jpe?g|gif)$/i,
@@ -30,8 +45,4 @@ module.exports = {
       },
     ]
   },
-  output: {
-    filename: 'bundle.js',
-    path: __dirname + '/client/dist'
-  }
 };

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const common = require('./webpack.common');
+const { merge } = require('webpack-merge');
+
+module.exports = merge(common, {
+  mode: 'development',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, '/client/dist')
+  }
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const common = require('./webpack.common');
+const { merge } = require('webpack-merge');
+
+module.exports = merge(common, {
+  mode: 'production',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'client/dist')
+  }
+});


### PR DESCRIPTION
## Description:
This PR improves upon the existing webpack configuration. The new 'npm start' command will start a development server that allows for "[hot module replacement](https://webpack.js.org/guides/hot-module-replacement/)"

## Context:
Separating production and development builds is [helpful for a number of reasons](https://webpack.js.org/guides/production/). 
_The goals of development and production builds differ greatly. In development, we want strong source mapping and a localhost server with live reloading or hot module replacement. In production, our goals shift to a focus on minified bundles, lighter weight source maps, and optimized assets to improve load time. With this logical separation at hand, we typically recommend writing separate webpack configurations for each environment._
-[webpack docs](https://webpack.js.org/guides/production/)



## Checklist:
[x] renamed webpack.config.js to webpack.common.js
[x] added 'start' and 'build' scripts to package.json
[x] added webpack config files for dev and production
[x] added a template.html to inject bundle.js into (useful if we want to add a hash to our production build filename).

## Notes:
After this PR has been merged, you will need to run `npm install` and then you can start the dev server using the `npm start` command. To generate a production build, you can use the `npm build` command.

### Screenshots (if any):
n/a

## Link to story (if available):
n/a