### PR TITLE
Webpack nodemon integration

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -4,8 +4,7 @@ import Reviews from './Reviews/Reviews.jsx';
 import ProductOverview from './ProductDetails/ProductOverview.jsx';
 import QuestionList from './QandA/QuestionList.jsx';
 import RelatedItems from './RelatedItems/RelatedItems.jsx';
-const axios = require('axios');
-import NavBar from './Navbar.jsx';
+import NavBar from './NavBar.jsx';
 
 class App extends React.Component {
   constructor(props) {
@@ -80,7 +79,10 @@ class App extends React.Component {
               data={this.state.questionList}
               currentProductID={this.state.currentProductID}
               currentProductName={this.state.currentProduct.name}/>
-            <Reviews reviewsData={this.state.reviews}/>
+            <Reviews
+              reviewsData={this.state.reviews}
+              currentProductID={this.state.currentProductID}
+              />
           </div>
         </div>
       );

--- a/client/src/components/Reviews/Reviews.jsx
+++ b/client/src/components/Reviews/Reviews.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReviewSummary from './ReviewSummary/ReviewSummary.jsx';
 import ReviewList from './ReviewList/ReviewList.jsx';
-import sampleData from './reviewsData.js';
 import './reviews.css';
 
 class Reviews extends React.Component {
@@ -18,8 +17,9 @@ class Reviews extends React.Component {
   }
 
   render() {
-    let { reviewsMetadata, reviews } = sampleData;
-    let { starFilter, productId } = this.state;
+    let { starFilter } = this.state;
+    let { reviewsData, currentProductID } = this.props;
+    let { reviewsMetadata, reviews } = reviewsData;
     return (
       <div>
         <h3>RATINGS &#38; REVIEWS</h3>
@@ -36,4 +36,7 @@ class Reviews extends React.Component {
     );
   }
 }
+
+
+
 export default Reviews;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "start": "webpack-dev-server --config webpack.dev.js --open",
+    "start": "webpack-dev-server --config webpack.dev.js --open --port 3000",
     "build": "webpack --config webpack.prod.js",
     "start-server": "npx nodemon server/index.js"
   },

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const port = 3070;
-const api = require('/.helpers.js');
+const api = require('./helpers.js');
 
 
 const app = express();

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -9,21 +9,12 @@ module.exports = merge(common, {
     path: path.resolve(__dirname, '/client/dist')
   },
   devServer: {
-
-    // historyApiFallback: true,
-    // hot: true,
-    //inline: true,
-
-    // host: 'localhost', // Defaults to `localhost`
-    // port: 3000, // Defaults to 8080
+    hot: true,
     proxy: {
       '/products': {
         target: 'http://localhost:3070',
-        // secure: false
       }
     }
   },
 
 });
-
-

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -7,5 +7,23 @@ module.exports = merge(common, {
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, '/client/dist')
-  }
+  },
+  devServer: {
+
+    // historyApiFallback: true,
+    // hot: true,
+    //inline: true,
+
+    // host: 'localhost', // Defaults to `localhost`
+    // port: 3000, // Defaults to 8080
+    proxy: {
+      '/products': {
+        target: 'http://localhost:3070',
+        // secure: false
+      }
+    }
+  },
+
 });
+
+

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,7 +11,7 @@ module.exports = merge(common, {
   devServer: {
     hot: true,
     proxy: {
-      '/products': {
+      '/': {
         target: 'http://localhost:3070',
       }
     }


### PR DESCRIPTION
## Description:
Configured webpack dev server to proxy axios requests (sent from client-side) to the dev server (nodedemon). 

## Context:
This is a common configuration required when running nodemon on one port and webpack on a separate port ([read more](https://stackoverflow.com/questions/35233291/running-a-node-express-server-using-webpack-dev-server)).

## Checklist:
[x] Updated webpack dev config file to proxy requests to development (nodemon) server at port 3070
[x] Updated `npm start` to run on port 3000
[x] Updated props being passed to Reviews Component

## Notes:
You may need to run 'npm install' to install the newly added dependencies (and get ESlint working)

### Screenshots (if any):
n/a

## Link to story (if available):
n/a