### PR TITLE
RelatedItems - Change current product being rendered on App

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -35,6 +35,9 @@ class App extends React.Component {
       let {currentProduct, productStylesArray, reviews, questionList} = cachedProduct;
       parserFunctions.getRelatedItems(productId, this.cachedProducts)
         .then(relatedItems => {
+          relatedItems.forEach(relatedItem => {
+            this.cachedProducts[relatedItem.currentProduct.id] = relatedItem;
+          });
           this.setState({
             currentProductID: productId,
             currentProduct,

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -95,7 +95,29 @@ class App extends React.Component {
     this.setState({
       favoriteProducts: updatedFavoriteProducts
     });
+  }
 
+  changeCurrentProduct(productId) {
+    let updatedProductInfo = this.cachedProducts[productId];
+    let {currentProduct, productStylesArray, reviews, questionList} = updatedProductInfo;
+    parserFunctions.getRelatedItems(productId, this.cachedProducts)
+      .then(relatedItems => {
+        relatedItems.filter(relatedItem => {
+          return !this.cachedProducts[relatedItem.currentProduct.id];
+        })
+          .forEach(relatedItem => {
+            this.cachedProducts[relatedItem.currentProduct.id] = relatedItem;
+          });
+        this.setState({
+          currentProductID: productId,
+          currentStyleID: productStylesArray[0].style_id,
+          currentProduct,
+          productStylesArray,
+          reviews,
+          questionList,
+          relatedItems
+        });
+      });
   }
 
   render() {
@@ -110,7 +132,7 @@ class App extends React.Component {
             changeCurrentStyle={this.changeCurrentStyle}
           />
           <div className="container">
-            <RelatedItems relatedProductsInfo={this.state.relatedItems} currentProduct={this.state.currentProduct} favoriteProducts={this.state.favoriteProducts} addProductToFavorites={this.addProductToFavorites.bind(this)} removeProductFromFavorites={this.removeProductFromFavorites.bind(this)}/>
+            <RelatedItems relatedProductsInfo={this.state.relatedItems} currentProduct={this.state.currentProduct} favoriteProducts={this.state.favoriteProducts} addProductToFavorites={this.addProductToFavorites.bind(this)} removeProductFromFavorites={this.removeProductFromFavorites.bind(this)} changeCurrentProduct={this.changeCurrentProduct.bind(this)}/>
             <QuestionList
               data={this.state.questionList}
               currentProductID={this.state.currentProductID}

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -138,7 +138,7 @@ class App extends React.Component {
   }
 
   render() {
-    let { currentProduct, productStylesArray, currentStyleID } = this.state;
+    let { currentProduct, productStylesArray, currentStyleID, relatedItems, favoriteProducts } = this.state;
 
     if (this.state.currentProductID) {
       return (
@@ -152,7 +152,7 @@ class App extends React.Component {
             changeCurrentStyle={this.changeCurrentStyle}
           />
           <div className="container">
-            <RelatedItems relatedProductsInfo={this.state.relatedItems} currentProduct={this.state.currentProduct} favoriteProducts={this.state.favoriteProducts} addProductToFavorites={this.addProductToFavorites.bind(this)} removeProductFromFavorites={this.removeProductFromFavorites.bind(this)} changeCurrentProduct={this.changeCurrentProduct.bind(this)}/>
+            <RelatedItems relatedProductsInfo={relatedItems} currentProduct={currentProduct} favoriteProducts={favoriteProducts} addProductToFavorites={this.addProductToFavorites.bind(this)} removeProductFromFavorites={this.removeProductFromFavorites.bind(this)} changeCurrentProduct={this.changeCurrentProduct.bind(this)}/>
             <QuestionList
               data={this.state.questionList}
               currentProductID={this.state.currentProductID}

--- a/client/src/components/RelatedItems/ProductCard.jsx
+++ b/client/src/components/RelatedItems/ProductCard.jsx
@@ -5,18 +5,25 @@ import noImageAvailable from './noImageAvailable.jpeg';
 import Stars from '../SharedComponents/Stars.jsx';
 import utilityFns from '../../utilityFns.js';
 
-function ProductCard({relatedProductInfo, productCardType, removeProductFromFavorites}) {
+function ProductCard({relatedProductInfo, productCardType, removeProductFromFavorites, changeCurrentProduct}) {
   let {currentProduct,
     productStylesArray,
     reviews} = relatedProductInfo;
   const imageSource = productStylesArray[0].photos[0].url ? productStylesArray[0].photos[0].url : noImageAvailable;
   const productprice = Number(currentProduct.default_price);
   let {averageRating} = utilityFns.processReviewMetadata(reviews.reviewsMetadata);
+
+  let cardOnClick = () => {
+    if (productCardType === 'RelatedProducts') {
+      changeCurrentProduct(currentProduct.id);
+    }
+  };
+
   return (
     <div className="card border-dark" style={{width: '20em', margin: '1em', position: 'relative'}}>
-      <img className="card-img-top" src={imageSource} style={{width: 'auto', height: '20vw', objectFit: 'cover'}} alt="Product image"></img>
+      <img className="card-img-top" src={imageSource} style={{width: 'auto', height: '20vw', objectFit: 'cover'}} alt="Product image" onClick={cardOnClick}></img>
       <ActionButton productCardType={productCardType} removeProductFromFavorites={removeProductFromFavorites} productId={currentProduct.id}/>
-      <div className="card-body">
+      <div className="card-body" onClick={cardOnClick}>
         <p className="card-text"><small className="text-muted">{currentProduct.category.toUpperCase()}</small></p>
         <h5 className="card-title">{currentProduct.name}</h5>
         <p className="card-text"><small className="text-muted">${productprice}</small></p>
@@ -33,6 +40,7 @@ ProductCard.propTypes = {
   reviews: PropTypes.object,
   productCardType: PropTypes.string,
   removeProductFromFavorites: PropTypes.func,
+  changeCurrentProduct: PropTypes.func,
 };
 
 export default ProductCard;

--- a/client/src/components/RelatedItems/RelatedItems.jsx
+++ b/client/src/components/RelatedItems/RelatedItems.jsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import RelatedProducts from './RelatedProducts.jsx';
 import YourOutfit from './YourOutfit.jsx';
 
-function RelatedItems({relatedProductsInfo, currentProduct, favoriteProducts, addProductToFavorites, removeProductFromFavorites}) {
+function RelatedItems({relatedProductsInfo, currentProduct, favoriteProducts, addProductToFavorites, removeProductFromFavorites, changeCurrentProduct}) {
   return (
     <div>
-      <RelatedProducts currentProductInfo={currentProduct} relatedProductsInfo={relatedProductsInfo}/>
+      <RelatedProducts currentProductInfo={currentProduct} relatedProductsInfo={relatedProductsInfo} changeCurrentProduct={changeCurrentProduct}/>
       <YourOutfit outfitProductsInfo={favoriteProducts} addProductToFavorites={addProductToFavorites} removeProductFromFavorites={removeProductFromFavorites}/>
     </div>
   );
@@ -19,6 +19,7 @@ RelatedItems.propTypes = {
   favoriteProducts: PropTypes.array,
   addProductToFavorites: PropTypes.func,
   removeProductFromFavorites: PropTypes.func,
+  changeCurrentProduct: PropTypes.func,
 };
 
 export default RelatedItems;

--- a/client/src/components/RelatedItems/RelatedProducts.jsx
+++ b/client/src/components/RelatedItems/RelatedProducts.jsx
@@ -4,7 +4,7 @@ import ProductCard from './ProductCard.jsx';
 import ComparisonModal from './ComparisonModal.jsx';
 import './relatedItemsStyle.css';
 
-function RelatedProducts({currentProductInfo, relatedProductsInfo}) {
+function RelatedProducts({currentProductInfo, relatedProductsInfo, changeCurrentProduct}) {
   const [currentCardIndex, setCurrentCardIndex] = useState(0);
   const carrouselLength = relatedProductsInfo.length;
 
@@ -33,7 +33,7 @@ function RelatedProducts({currentProductInfo, relatedProductsInfo}) {
           <div className="carousel-inner">
             <div className="carousel-card" style={{ transform: `translateX(-${currentCardIndex * (100 / 3.81)}%)` }}>
               {relatedProductsInfo.map((relatedProductInfo) => {
-                return (<ProductCard key={relatedProductInfo.currentProduct.id} relatedProductInfo={relatedProductInfo}/>);
+                return (<ProductCard key={relatedProductInfo.currentProduct.id} relatedProductInfo={relatedProductInfo} changeCurrentProduct={changeCurrentProduct} productCardType={'RelatedProducts'} />);
               })}
             </div>
           </div>
@@ -51,7 +51,8 @@ function RelatedProducts({currentProductInfo, relatedProductsInfo}) {
 
 RelatedProducts.propTypes = {
   currentProductInfo: PropTypes.object,
-  relatedProductsInfo: PropTypes.array
+  relatedProductsInfo: PropTypes.array,
+  changeCurrentProduct: PropTypes.func,
 };
 
 export default RelatedProducts;


### PR DESCRIPTION
## Description:
Add functions that add and remove products from user YourOutfit

## Context:
This PR changes App to render a new product page every time the user clicks a product on a related product feature.

component tree
App
--RelatedItems
----RelatedProducts
------ProductCard

## Checklist:
[x] Changed getProductData function to add related products data to cacheProducts object
[x] Implemented function changeCurrentProduct on App that changes page based product clicked by the user
[x] Change props names passed from App to RelatedItems component 

## Notes:
I plan to refactor the function later to use part of the getProductData implementation as it has a lot of repeated code.
This will change how the product Overview is being rendered, but I talked to Alexander about that.

## Screenshots:
https://user-images.githubusercontent.com/75865828/148446888-6ad4faa5-522f-44cb-8d97-731e063dbdb5.mov

## Link to story
<img width="667" alt="Screen Shot 2022-01-06 at 2 26 30 PM" src="https://user-images.githubusercontent.com/75865828/148447021-969492a7-c1bc-4f3a-878a-fe1cefeb0c63.png">
: