### PR TITLE
ProductOverview - Fix Product Overview Main Image Bug

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -139,7 +139,8 @@ class App extends React.Component {
           productStylesArray,
           reviews,
           questionList,
-          relatedItems
+          relatedItems,
+          mainImage: productStylesArray[0].photos[0].url,
         });
       });
   }


### PR DESCRIPTION
## Description:
Fix Product Overview Main Image Bug

## Context:
When the user clicked one style photo (photo from the carousel in the right), that photo was getting fixed to the main image in the product overview, and it wouldn't change, even if the user clicked a new product.
To fix that bug, I added the main image to be changed when changeCurrentProduct function is called.

## Checklist:
[x] Added main image to be changed when changeCurrentProduct function is called

## Screenshots:

https://user-images.githubusercontent.com/75865828/148581887-2fa4f8bf-6f85-4ed4-90fc-eb08d70c5d33.mov
